### PR TITLE
Detect and remove any user accounts that are not explicitly configured

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,20 @@ Tequila-common
 
 Changes
 
+v 0.8.2 on Nov 20, 2017
+-----------------------
+
+* Remove user accounts that are not within either ``users`` or the new
+  ``unmanaged_users`` list.
+
+  Before upgrading and deploying with this version, the servers
+  covered under this role should be checked for accounts that have a
+  home directory under /home/, are not stale developer users, but are
+  not currently captured under the ``users`` variable.  These special
+  users, if the assessment concludes that they need to remain, should
+  be added to the ``unmanaged_users`` list.
+
+
 v 0.8.1 on Oct 20, 2017
 -----------------------
 
@@ -10,6 +24,7 @@ v 0.8.1 on Oct 20, 2017
   If you were previously not using tequila-nginx, but you WERE
   customizing ``ssl_dir``, then you'll need to create a task outside
   Tequila to create your customized ``ssl_dir`` directory.
+
 
 v 0.8.0 on May 3, 2017
 ----------------------

--- a/README.rst
+++ b/README.rst
@@ -98,9 +98,10 @@ The ``unmanaged_users`` variable is a list that is intended to hold
 any special-case users that have been created by other means, that it
 is not desirable to remove as stale.  All users that have a directory
 under /home/ and that are not in either ``users`` or
-``unmanaged_users`` will be removed on each run of this role.
-However, the users' files and directories will not be removed.  This
-variable should look something like ::
+``unmanaged_users`` (not counting the special user that owns the files
+from the codebase) will be removed on each run of this role.  However,
+the users' files and directories will not be removed.  This variable
+should look something like ::
 
     unmanaged_users:
       - special_user1

--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,7 @@ role:
 - ``project_name`` **required**
 - ``env_name`` **required** e.g. ``'staging'``
 - ``users`` **default:** empty list
+- ``unmanaged_users`` **default:** empty list
 - ``root_dir`` **default:** ``"/var/www/{{ project_name }}"``
 - ``log_dir`` **default:** ``"{{ root_dir }}/log"``
 - ``public_dir`` **default:** ``"{{ root_dir }}/public"``
@@ -92,3 +93,16 @@ a list of the user's public ssh keys.  So, a typical definition for
       - name: user3
         public_keys:
           - "ssh-rsa AAAAAA user3@example.com"
+
+The ``unmanaged_users`` variable is a list that is intended to hold
+any special-case users that have been created by other means, that it
+is not desirable to remove as stale.  All users that have a directory
+under /home/ and that are not in either ``users`` or
+``unmanaged_users`` will be removed on each run of this role.
+However, the users' files and directories will not be removed.  This
+variable should look something like ::
+
+    unmanaged_users:
+      - special_user1
+      - special_user2
+      - special_user3

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 users: []
+unmanaged_users: []
 root_dir: "/var/www/{{ project_name }}"
 log_dir: "{{ root_dir }}/log"
 public_dir: "{{ root_dir }}/public"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -77,6 +77,19 @@
     - "{{ users }}"
     - public_keys
 
+- name: check the active user accounts
+  shell: "getent passwd $(basename -a /home/*) | cut -d: -f1"
+  register: current_users_out
+
+- name: disable user accounts that are not listed devs or unmanaged accounts
+  user:
+    name: "{{ item }}"
+    state: absent
+  with_items: "{{ current_users | difference(active_users) | difference(unmanaged_users) }}"
+  vars:
+    current_users: "{{ current_users_out.stdout_lines }}"
+    active_users: "{{ users | map(attribute='name') | list }}"
+
 # Now that we've hopefully configured some non-root users to be able to ssh
 # in, update the sshd config, which (among other things) will disable root
 # logins.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,7 +87,7 @@
     state: absent
   with_items: "{{ current_users | difference(active_users) | difference(unmanaged_users) }}"
   vars:
-    current_users: "{{ current_users_out.stdout_lines }}"
+    current_users: "{{ current_users_out.stdout_lines | difference([project_name]) }}"
     active_users: "{{ users | map(attribute='name') | list }}"
 
 # Now that we've hopefully configured some non-root users to be able to ssh


### PR DESCRIPTION
These are accounts that have a directory under /home, are listed in
/etc/passwd, and are not configured in either of `users` or
`unmanaged_users`.

The new `unmanaged_users` variable does not create the accounts
listed, merely prevents them from being purged, to be used for special
case or legacy accounts that should not be removed.

TEQ-27 and SEC-87

fixes #7