### PR TITLE
Add support for setting the project user's private key

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,13 @@ Tequila-common
 
 Changes
 
+v 0.8.5 on TBD
+-----------------------
+
+* Added ``project_user_private_key`` to allow specification of the project
+  user's private SSH key (.ssh/id_rsa).
+
+
 v 0.8.4 on Apr 19, 2018
 -----------------------
 

--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,7 @@ role:
 - ``ssh_dir`` **default:** ``"/home/{{ project_name }}/.ssh"``
 - ``use_newrelic`` **default:** ``false``
 - ``new_relic_license_key`` **required if use_newrelic = true**
+- ``project_user_private_key`` **default:** ``''``
 
 The ``users`` variable is meant to be a list of dicts, where each dict
 represents a developer.  There are two required keys for each dict:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ static_dir: "{{ root_dir }}/public/static"
 media_dir: "{{ root_dir }}/public/media"
 ssh_dir: "/home/{{ project_name }}/.ssh"
 use_newrelic: false
+project_user_private_key: ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -146,3 +146,17 @@
         owner={{ project_name }}
         group={{ project_name }}
         mode=700
+
+- name: store path to private SSH key
+  set_fact:
+    project_user_key_path: "{{ ssh_dir }}/id_rsa"
+  when: project_user_private_key|default('')
+
+- name: upload private SSH key
+  copy: content={{ project_user_private_key }}
+        dest={{ project_user_key_path }}
+        owner={{ project_name }}
+        group={{ project_name }}
+        mode=600
+  register: project_user_key
+  when: project_user_private_key|default('')


### PR DESCRIPTION
GitHub deploy keys only grant access to a single repository. Sometimes a project may require access to several different private GitHub repos. For example, if a pip requirements file references several private Git repos. GitHub suggests using a [Machine User](https://developer.github.com/v3/guides/managing-deploy-keys/) in this scenario.

This PR proposes to allow specification of the project user's private SSH key from ansible vault. Then any git pull (whether invoked directly by git or within pip) will use this SSH key.