### PR TITLE
Break out a new configuration variable, project_user

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,13 @@ Tequila-common
 
 Changes
 
+v 0.8.X on XXX XX, 2018
+-----------------------
+
+* Configure the project user separately from the project name, as
+  tequila-django does.
+
+
 v 0.8.4 on Apr 19, 2018
 -----------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Tequila-common
 
 Changes
 
-v 0.8.X on XXX XX, 2018
+v 0.8.5 on Jul 24, 2018
 -----------------------
 
 * Configure the project user separately from the project name, as

--- a/README.rst
+++ b/README.rst
@@ -70,13 +70,14 @@ role:
 - ``project_name`` **required**
 - ``env_name`` **required** e.g. ``'staging'``
 - ``users`` **default:** empty list
+- ``project_user`` **default:** ``"{{ project_name }}"``
 - ``unmanaged_users`` **default:** empty list
 - ``root_dir`` **default:** ``"/var/www/{{ project_name }}"``
 - ``log_dir`` **default:** ``"{{ root_dir }}/log"``
 - ``public_dir`` **default:** ``"{{ root_dir }}/public"``
 - ``static_dir`` **default:** ``"{{ root_dir }}/public/static"``
 - ``media_dir`` **default:** ``"{{ root_dir }}/public/media"``
-- ``ssh_dir`` **default:** ``"/home/{{ project_name }}/.ssh"``
+- ``ssh_dir`` **default:** ``"/home/{{ project_user }}/.ssh"``
 - ``use_newrelic`` **default:** ``false``
 - ``new_relic_license_key`` **required if use_newrelic = true**
 

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ directory ::
     ---
     # file: deployment/requirements.yml
     - src: https://github.com/caktus/tequila-common
-      version: 0.1.0
+      version: 0.8.5
 
 Run ``ansible-galaxy`` with your requirements file ::
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,11 @@
 ---
 users: []
 unmanaged_users: []
+project_user: "{{ project_name }}"
 root_dir: "/var/www/{{ project_name }}"
 log_dir: "{{ root_dir }}/log"
 public_dir: "{{ root_dir }}/public"
 static_dir: "{{ root_dir }}/public/static"
 media_dir: "{{ root_dir }}/public/media"
-ssh_dir: "/home/{{ project_name }}/.ssh"
+ssh_dir: "/home/{{ project_user }}/.ssh"
 use_newrelic: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,7 +87,7 @@
     state: absent
   with_items: "{{ current_users | difference(active_users) | difference(unmanaged_users) }}"
   vars:
-    current_users: "{{ current_users_out.stdout_lines | difference([project_name]) }}"
+    current_users: "{{ current_users_out.stdout_lines | difference([project_user]) }}"
     active_users: "{{ users | map(attribute='name') | list }}"
 
 # Now that we've hopefully configured some non-root users to be able to ssh
@@ -99,8 +99,8 @@
     - restart sshd
 
 - name: create the project user
-  user: name={{ project_name }}
-        home=/home/{{ project_name }}
+  user: name={{ project_user }}
+        home=/home/{{ project_user }}
         shell=/bin/bash
         groups=www-data
         append=yes # appends the group(s) set above to the user's set of groups
@@ -108,21 +108,21 @@
 - name: create the project root directory
   file: path={{ root_dir }}
         state=directory
-        owner={{ project_name }}
-        group={{ project_name }}
+        owner={{ project_user }}
+        group={{ project_user }}
         mode=775
 
 - name: create the log directory
   file: path={{ log_dir }}
         state=directory
-        owner={{ project_name }}
+        owner={{ project_user }}
         group=www-data
         mode=775
 
 - name: create the public directory
   file: path={{ public_dir }}
         state=directory
-        owner={{ project_name }}
+        owner={{ project_user }}
         group=www-data
         mode=775
 
@@ -130,19 +130,19 @@
   file: path={{ static_dir }}
         state=directory
         mode=0755
-        group={{ project_name }}
-        owner={{ project_name }}
+        group={{ project_user }}
+        owner={{ project_user }}
 
 - name: media dir
   file: path={{ media_dir }}
         state=directory
         mode=0755
-        group={{ project_name }}
-        owner={{ project_name }}
+        group={{ project_user }}
+        owner={{ project_user }}
 
 - name: create the user ssh directory
   file: path={{ ssh_dir }}
         state=directory
-        owner={{ project_name }}
-        group={{ project_name }}
+        owner={{ project_user }}
+        group={{ project_user }}
         mode=700


### PR DESCRIPTION
For compatibility with tequila-django, since it allows that variable
to be separately configured from project_name.