### PR TITLE
Move SSH agent forwarding setup to occur after project_user is created

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,12 @@ Tequila-common
 
 Changes
 
+v 0.8.7 on Aug 9, 2018
+----------------------
+
+* Bug fix to run SSH agent forwarding configuration after creation of project_user.
+
+
 v 0.8.6 on Jul 30, 2018
 -----------------------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,6 +105,8 @@
         groups=www-data
         append=yes # appends the group(s) set above to the user's set of groups
 
+# The next task must occur AFTER project_user creation
+
 # This arranges for *FUTURE* connections to allow the project_user to access the
 # socket connected to the forwarded ssh agent.  We'll also run the command
 # directly from the next task, but this allows users to run other ansible plays

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,50 +1,4 @@
 ---
-# This arranges for *FUTURE* connections to allow the project_user to access the
-# socket connected to the forwarded ssh agent.  We'll also run the command
-# directly from the next task, but this allows users to run other ansible plays
-# without first running tequila-common, and still take advantage of agent
-# forwarding.
-#
-# We are assuming all the projects use the same user.
-#
-# https://serverfault.com/questions/107187/ssh-agent-forwarding-and-sudo-to-another-user
-- name: Set up /etc/ssh/sshrc to open up the ssh auth sock to {{ project_user }} iffi the agent was forwarded
-  when: project_user is defined
-  become: true
-  lineinfile:
-    path: /etc/ssh/sshrc
-    backup: yes
-    create: yes
-    line: if [ -n "$SSH_AUTH_SOCK" ] ; then setfacl -m u:{{ project_user }}:rx $(dirname "$SSH_AUTH_SOCK") -m u:{{ project_user }}:rwx "$SSH_AUTH_SOCK"; fi
-
-# This opens up the forwarded ssh agent socket for this connection
-# so the project_user can use it.
-#
-# It's only really needed the first time tequila-common is run. After
-# that, the /etc/ssh/sshrc script created above will do it on the
-# establishment of every connection.
-#
-# This must not sudo before running, because we might not yet have fixed
-# the sudo config to pass the SSH_AUTH_SOCK value through. It's okay not
-# to sudo, because the connecting user must have access to the socket
-# or they couldn't use it themselves, and so should be able to change
-# its permissions.
-#
-# We just run the /etc/ssh/sshrc we just created, rather than put the
-# ACL commands in two places (staying DRY).
-- name: open up ssh agent forwarding socket
-  become: false
-  shell: . /etc/ssh/sshrc
-
-# sudo needs to pass through the environment variable pointing at the
-# forwarded ssh agent socket, so sudo commands know where it is.
-- name: Configure sudo so ssh agent forwarding survives sudo
-  lineinfile:
-    dest: /etc/sudoers
-    state: present
-    regexp: SSH_AUTH_SOCK
-    line: Defaults env_keep += "SSH_AUTH_SOCK"
-
 - name: install base packages
   apt: pkg={{ item }} state=present update-cache=yes cache_valid_time=3600
   with_items:
@@ -150,6 +104,52 @@
         shell=/bin/bash
         groups=www-data
         append=yes # appends the group(s) set above to the user's set of groups
+
+# This arranges for *FUTURE* connections to allow the project_user to access the
+# socket connected to the forwarded ssh agent.  We'll also run the command
+# directly from the next task, but this allows users to run other ansible plays
+# without first running tequila-common, and still take advantage of agent
+# forwarding.
+#
+# We are assuming all the projects use the same user.
+#
+# https://serverfault.com/questions/107187/ssh-agent-forwarding-and-sudo-to-another-user
+- name: Set up /etc/ssh/sshrc to open up the ssh auth sock to {{ project_user }} iffi the agent was forwarded
+  when: project_user is defined
+  become: true
+  lineinfile:
+    path: /etc/ssh/sshrc
+    backup: yes
+    create: yes
+    line: if [ -n "$SSH_AUTH_SOCK" ] ; then setfacl -m u:{{ project_user }}:rx $(dirname "$SSH_AUTH_SOCK") -m u:{{ project_user }}:rwx "$SSH_AUTH_SOCK"; fi
+
+# This opens up the forwarded ssh agent socket for this connection
+# so the project_user can use it.
+#
+# It's only really needed the first time tequila-common is run. After
+# that, the /etc/ssh/sshrc script created above will do it on the
+# establishment of every connection.
+#
+# This must not sudo before running, because we might not yet have fixed
+# the sudo config to pass the SSH_AUTH_SOCK value through. It's okay not
+# to sudo, because the connecting user must have access to the socket
+# or they couldn't use it themselves, and so should be able to change
+# its permissions.
+#
+# We just run the /etc/ssh/sshrc we just created, rather than put the
+# ACL commands in two places (staying DRY).
+- name: open up ssh agent forwarding socket
+  become: false
+  shell: . /etc/ssh/sshrc
+
+# sudo needs to pass through the environment variable pointing at the
+# forwarded ssh agent socket, so sudo commands know where it is.
+- name: Configure sudo so ssh agent forwarding survives sudo
+  lineinfile:
+    dest: /etc/sudoers
+    state: present
+    regexp: SSH_AUTH_SOCK
+    line: Defaults env_keep += "SSH_AUTH_SOCK"
 
 - name: create the project root directory
   file: path={{ root_dir }}


### PR DESCRIPTION
``setfacl`` fails if ``project_user`` doesn't exist.