### PR TITLE
Fix for Ansible 2.7.8/2.7.9

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,13 @@ Tequila-common
 
 Changes
 
+v ?.?.?
+-------
+
+* Fix for Ansible 2.7.9: include direction on ufw tasks. (Became required
+  in Ansible 2.7.8 or 2.7.9, not documented yet but see
+  https://github.com/ansible/ansible/issues/53854)
+
 v 0.8.9 on Sep 17, 2018
 -----------------------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -89,10 +89,10 @@
   copy: src=admin dest=/etc/sudoers.d/admin owner=root mode=0440
 
 - name: allow ssh through firewall
-  ufw: rule=allow port=ssh
+  ufw: rule=allow port=ssh direction=in
 
 - name: ensure ufw is turned on
-  ufw: state=enabled policy=deny
+  ufw: state=enabled policy=deny direction=incoming
 
 - name: ensure postfix is turned on
   service: name=postfix state=started


### PR DESCRIPTION
Include direction on ufw tasks, which apparently is no
longer optional. (Makes sense, though.)