### PR TITLE
Use module:options format for all tasks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,14 @@ Tequila-common
 
 Changes
 
+v 0.9.1 on ???
+----------------------
+
+* Consistently use the `recommended module:options format
+  <https://docs.ansible.com/ansible/latest/user_guide/playbooks_intro.html#action-shorthand>`_
+  for all tasks.
+* Change ``include`` to ``include_tasks``.
+
 v 0.9.0 on Apr 1, 2019
 ----------------------
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,10 @@
 ---
 - name: restart sshd
-  service: name=ssh state=restarted
+  service:
+    name: ssh
+    state: restarted
 
 - name: restart fail2ban
-  service: name=fail2ban state=restarted
+  service:
+    name: fail2ban
+    state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Django project deployment -- common
   company: Caktus Consulting Group, LLC
   license: BSD
-  min_ansible_version: 1.9
+  min_ansible_version: 2.4
   platforms:
     - name: Ubuntu
       versions: all

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -232,8 +232,8 @@
     - path: "{{ public_dir }}"
       group: www-data
     - path: "{{ static_dir }}"
-      mode: 0755
+      mode: "0755"
     - path: "{{ media_dir }}"
-      mode: 0755
+      mode: "0755"
     - path: "{{ ssh_dir }}"
-      mode: 0700
+      mode: "0700"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,7 @@
 - name: open up ssh agent forwarding socket
   become: false
   shell: . /etc/ssh/sshrc
+  changed_when: true
 
 # sudo needs to pass through the environment variable pointing at the
 # forwarded ssh agent socket, so sudo commands know where it is.
@@ -46,19 +47,31 @@
     line: Defaults env_keep += "SSH_AUTH_SOCK"
 
 - name: install Ubuntu<18.04 base packages
-  apt: pkg={{ item }} state=present update-cache=yes cache_valid_time=3600
+  apt:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version < "18"
   with_items:
     - python-software-properties
 
 - name: install Ubuntu>=18.04 base packages
-  apt: pkg={{ item }} state=present update-cache=yes cache_valid_time=3600
+  apt:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version >= "18"
   with_items:
     - software-properties-common
 
 - name: install base packages
-  apt: pkg={{ item }} state=present update-cache=yes cache_valid_time=3600
+  apt:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
   with_items:
     - dpkg-dev
     - wget
@@ -76,60 +89,97 @@
     - apt-transport-https
     - lsof
 
-- include: newrelic.yml
+- include_tasks: newrelic.yml
   when: use_newrelic
 
 - name: ensure that the admin and login groups are present
-  group: name={{ item }} state=present system=yes
+  group:
+    name: "{{ item }}"
+    state: present
+    system: yes
   with_items:
     - admin
     - login
 
 - name: allow admin group users to sudo
-  copy: src=admin dest=/etc/sudoers.d/admin owner=root mode=0440
+  copy:
+    src: admin
+    dest: /etc/sudoers.d/admin
+    owner: root
+    mode: 0440
 
 - name: allow ssh through firewall
-  ufw: rule=allow port=ssh direction=in
+  ufw:
+    rule: allow
+    port: ssh
+    direction: in
 
 - name: ensure ufw is turned on
-  ufw: state=enabled policy=deny direction=incoming
+  ufw:
+    state: enabled
+    policy: deny
+    direction: incoming
 
 - name: ensure postfix is turned on
-  service: name=postfix state=started
+  service:
+    name: postfix
+    state: started
 
 - name: ensure fail2ban is turned on
-  service: name=fail2ban state=started
+  service:
+    name: fail2ban
+    state: started
 
 - name: configure fail2ban
-  copy: src=jail.local dest=/etc/fail2ban/jail.local owner=root mode=0644
+  copy:
+    src: jail.local
+    dest: /etc/fail2ban/jail.local
+    owner: root
+    mode: 0644
   notify:
     - restart fail2ban
 
 - name: add github to the ssh known hosts
-  known_hosts: path=/etc/ssh/ssh_known_hosts
-               name='github.com'
-               key="{{ lookup('file', 'github.pub') }}"
+  known_hosts:
+    path: /etc/ssh/ssh_known_hosts
+    name: github.com
+    key: "{{ lookup('file', 'github.pub') }}"
 
 - name: set the locale to utf8
-  lineinfile: line={{ item }} dest=/etc/default/locale state=present create=yes owner=root mode=0644
+  lineinfile:
+    line: "{{ item }}"
+    dest: /etc/default/locale
+    state: present
+    create: yes
+    owner: root
+    mode: 0644
   with_items:
     - "LC_ALL=en_US.UTF-8"
     - "LANG=en_US.UTF-8"
 
 - name: check that the project has some users configured
-  fail: msg="Please define one or more developers in the `users` variable"
+  fail:
+    msg: "Please define one or more developers in the `users` variable"
   when: not users
 
 - name: ensure that dev users are present
-  user: name={{ item.name }} shell=/bin/bash groups=admin,login append=yes
+  user:
+    name: "{{ item.name }}"
+    shell: /bin/bash
+    groups:
+      - admin
+      - login
+    append: yes
   with_items: "{{ users }}"
 
-- include: vagrant.yml
+- include_tasks: vagrant.yml
   when: env_name == 'local'
 
 # Note: this does a nested iteration, iterating over each user's defined keys.
 - name: add ssh keys for dev users
-  authorized_key: user={{ item.0.name }} key="{{ item.1 }}"
+  authorized_key:
+    user: "{{ item.0.name }}"
+    key: "{{ item.1 }}"
   with_subelements:
     - "{{ users }}"
     - public_keys
@@ -138,13 +188,18 @@
 # in, update the sshd config, which (among other things) will disable root
 # logins.
 - name: configure sshd
-  copy: src=sshd_config dest=/etc/ssh/sshd_config owner=root mode=0644
+  copy:
+    src: sshd_config
+    dest: /etc/ssh/sshd_config
+    owner: root
+    mode: 0644
   notify:
     - restart sshd
 
 - name: check the active user accounts
   shell: "getent passwd $(basename -a /home/*) | cut -d: -f1"
   register: current_users_out
+  changed_when: false
 
 - name: disable user accounts that are not listed devs, unmanaged accounts, or project users
   user:
@@ -156,50 +211,29 @@
     active_users: "{{ users | map(attribute='name') | list }}"
 
 - name: create the project user {{ project_user }}
-  user: name={{ project_user }}
-        home=/home/{{ project_user }}
-        shell=/bin/bash
-        groups=www-data
-        append=yes # appends the group(s) set above to the user's set of groups
+  user:
+    name: "{{ project_user }}"
+    home: "/home/{{ project_user }}"
+    shell: "/bin/bash"
+    groups: www-data
+    append: yes # appends the group(s) set above to the user's set of groups
 
-- name: create the project root directory
-  file: path={{ root_dir }}
-        state=directory
-        owner={{ project_user }}
-        group={{ project_user }}
-        mode=775
-
-- name: create the log directory
-  file: path={{ log_dir }}
-        state=directory
-        owner={{ project_user }}
-        group=www-data
-        mode=775
-
-- name: create the public directory
-  file: path={{ public_dir }}
-        state=directory
-        owner={{ project_user }}
-        group=www-data
-        mode=775
-
-- name: static dir
-  file: path={{ static_dir }}
-        state=directory
-        mode=0755
-        group={{ project_user }}
-        owner={{ project_user }}
-
-- name: media dir
-  file: path={{ media_dir }}
-        state=directory
-        mode=0755
-        group={{ project_user }}
-        owner={{ project_user }}
-
-- name: create the user ssh directory
-  file: path={{ ssh_dir }}
-        state=directory
-        owner={{ project_user }}
-        group={{ project_user }}
-        mode=700
+- name: create the project directories
+  file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner|default(project_user) }}"
+    group: "{{ item.group|default(project_user) }}"
+    mode: "{{ item.mode|default('0775') }}"
+  with_items:
+    - path: "{{ root_dir }}"
+    - path: "{{ log_dir }}"
+      group: www-data
+    - path: "{{ public_dir }}"
+      group: www-data
+    - path: "{{ static_dir }}"
+      mode: 0755
+    - path: "{{ media_dir }}"
+      mode: 0755
+    - path: "{{ ssh_dir }}"
+      mode: 0700

--- a/tasks/newrelic.yml
+++ b/tasks/newrelic.yml
@@ -1,6 +1,8 @@
 ---
 - name: add the newrelic repo key
-  apt_key: url="https://download.newrelic.com/548C16BF.gpg" state=present
+  apt_key:
+    url: "https://download.newrelic.com/548C16BF.gpg"
+    state: present
 
 - name: add newrelic repo
   apt_repository:
@@ -8,14 +10,19 @@
     state: present
 
 - name: install newrelic system monitoring
-  apt: pkg=newrelic-sysmond state=latest
+  apt:
+    name: newrelic-sysmond
+    state: latest
 
 - name: configure newrelic system monitoring
-  template: src=nrsysmond.cfg
-            dest=/etc/newrelic/nrsysmond.cfg
-            owner=newrelic
-            group=newrelic
-            mode=0440
+  template:
+    src: nrsysmond.cfg
+    dest: /etc/newrelic/nrsysmond.cfg
+    owner: newrelic
+    group: newrelic
+    mode: 0440
 
 - name: ensure that newrelic is running
-  service: name=newrelic-sysmond state=started
+  service:
+    name: newrelic-sysmond
+    state: started

--- a/tasks/vagrant.yml
+++ b/tasks/vagrant.yml
@@ -1,3 +1,8 @@
 ---
 - name: configure vagrant user
-  user: name=vagrant groups=admin,login append=yes
+  user:
+    name: vagrant
+    groups:
+      - admin
+      - login
+    append: yes


### PR DESCRIPTION
Consistently use the [recommended module:options format](https://docs.ansible.com/ansible/latest/user_guide/playbooks_intro.html#action-shorthand) for all tasks.

Change `include` to `include_tasks` (which limits role support to Ansible 2.4 and later only).

Fix a few other ansible-lint warnings and simplify creation of project-related directories.