### PR TITLE
Fix search for whether project user exists...

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,8 @@
     path: /etc/ssh/sshrc
     backup: yes
     create: yes
-    line: if [ -n "$SSH_AUTH_SOCK" ] ; then if grep --quiet {{ project_user }} /etc/passwd ; then setfacl -m u:{{ project_user }}:rx $(dirname "$SSH_AUTH_SOCK") -m u:{{ project_user }}:rwx "$SSH_AUTH_SOCK"; fi; fi
+    line: if [ -n "$SSH_AUTH_SOCK" ] ; then if grep --quiet "^{{ project_user }}:" /etc/passwd ; then setfacl -m u:{{ project_user }}:rx $(dirname "$SSH_AUTH_SOCK") -m u:{{ project_user }}:rwx "$SSH_AUTH_SOCK"; fi; fi
+    regex: "^if \\[ -n \\\"\\$SSH_AUTH_SOCK\\\" \\].*"
 
 # This opens up the forwarded ssh agent socket for this connection
 # so the project_user can use it.


### PR DESCRIPTION
 ...to only match the exact username. Added `regex` parameter to allow for applying this change to an existing `sshrc` file.