### PR TITLE
Use names list rather than loop with apt module

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@ Tequila-common
 
 Changes
 
+v 0.9.2 on ?
+-----------------------
+* Pass packages to apt module as list rather than using squash_actions, which is more efficient and removes deprecation warning
+
 v 0.9.1 on Sep 12, 2019
 -----------------------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,31 +49,25 @@
 
 - name: install Ubuntu<18.04 base packages
   apt:
-    name: "{{ item }}"
+    name:
+      - python-software-properties
     state: present
     update_cache: yes
     cache_valid_time: 3600
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version < "18"
-  with_items:
-    - python-software-properties
 
 - name: install Ubuntu>=18.04 base packages
   apt:
-    name: "{{ item }}"
+    name:
+      - software-properties-common
     state: present
     update_cache: yes
     cache_valid_time: 3600
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version >= "18"
-  with_items:
-    - software-properties-common
 
 - name: install base packages
   apt:
-    name: "{{ item }}"
-    state: present
-    update_cache: yes
-    cache_valid_time: 3600
-  with_items:
+    name:
     - dpkg-dev
     - wget
     - build-essential
@@ -89,6 +83,9 @@
     - rsync
     - apt-transport-https
     - lsof
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
 
 - include_tasks: newrelic.yml
   when: use_newrelic


### PR DESCRIPTION
Per [Notes](https://docs.ansible.com/ansible/latest/modules/apt_module.html) in Ansible ``apt`` docs, this method is more efficient and removes deprecation warning:

> When used with a loop: each package will be processed individually, it is much more efficient to pass the list directly to the name option.